### PR TITLE
Separate threads for image display

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -1,12 +1,6 @@
 Bugs -
-Image disply slowing down other core computations
-Solution-
-Create a seperate thread for display of imageSubscriber output
-Create a seperate thread for display of feature detection output
-Create a seperate thread for display of feature matching output
-
 In FeatureDetector::detectFeatures(), keypoints.empty() line is redundant once intial set of images have matched
-because the keypoints vector will never br empty after that since it is not cleared anywhere in the code.
+because the keypoints vector will never be empty after that since it is not cleared anywhere in the code.
 Solution-
 
 Verify that "keypoints1 = keypoints;" in FeatureMatcher::makePrevious() is correct without .clone()
@@ -18,6 +12,11 @@ The keypoint detection video stream window stops updating when camera is facing 
 Solution-
 Because no keypoint found on a flat textureless surface.
 
+Image disply slowing down other core computations
+Solution-
+Create a seperate thread for display of imageSubscriber output
+Create a seperate thread for display of feature detection output
+Create a seperate thread for display of feature matching output
 
 Tests -
 Go through feature detection code and optimize
@@ -32,3 +31,7 @@ Test motion extraction
 Done
 =========================================================================
 Test changes in imageSubscriber function
+
+
+Task-
+Add code to log exceptions where /// Raise exception comment is present.

--- a/TODO.txt
+++ b/TODO.txt
@@ -1,4 +1,34 @@
-1) Add descriptor calculator function in feature_detection.cpp
-2) Add feature matching code using these descriptors
-3) Add code to visually display matched features
-4) Add code to calculate motion from the pixel shift of the keypoints
+Bugs -
+Image disply slowing down other core computations
+Solution-
+Create a seperate thread for display of imageSubscriber output
+Create a seperate thread for display of feature detection output
+Create a seperate thread for display of feature matching output
+
+In FeatureDetector::detectFeatures(), keypoints.empty() line is redundant once intial set of images have matched
+because the keypoints vector will never br empty after that since it is not cleared anywhere in the code.
+Solution-
+
+Verify that "keypoints1 = keypoints;" in FeatureMatcher::makePrevious() is correct without .clone()
+
+=========================================================================
+Done
+=========================================================================
+The keypoint detection video stream window stops updating when camera is facing a flat textureless surface
+Solution-
+Because no keypoint found on a flat textureless surface.
+
+
+Tests -
+Go through feature detection code and optimize
+Test changes in feature detection code post-optimization
+Go through feature matching code and optimize
+Test changes in feature matching code post-optimization
+Test motion extraction code to debug
+Go through motion extraction code and optimize
+Test changes in motion extraction code post-optimization
+Test motion extraction
+=========================================================================
+Done
+=========================================================================
+Test changes in imageSubscriber function

--- a/src/camera_motion_extraction/include/feature_detection.h
+++ b/src/camera_motion_extraction/include/feature_detection.h
@@ -5,6 +5,10 @@
 /// header
 #include <opencv2/features2d.hpp>
 #include<image_subscriber.h>
+#include <thread>
+//#include <future>
+#include <mutex>
+#include <atomic>
 /// header
 
 
@@ -13,6 +17,11 @@ class FeatureDetector: public RosToCvmat {
   /// ORB object used to get 
   /// image keypoints and corresponding descriptors 
     cv::Ptr<cv::ORB> orb;
+    #ifdef DEBUG_MODE
+      //std::future<void> imgDispFut1;
+      bool ready;
+      std::mutex mtx1;
+    #endif
 
   protected:
     std::vector<cv::KeyPoint> keypoints;

--- a/src/camera_motion_extraction/include/feature_matching.h
+++ b/src/camera_motion_extraction/include/feature_matching.h
@@ -13,12 +13,17 @@ class FeatureMatcher: public FeatureDetector {
     cv::Ptr<cv::BFMatcher> bruteForceMatcher;
     std::vector<cv::DMatch> matches;
     cv::Mat matchedImage;
+    #ifdef DEBUG_MODE
+      bool ready1;
+      std::mutex mtx2;
+    #endif
     
   protected:
     cv::Mat preImage; // Previously recieved image
     std::vector<cv::KeyPoint> keypoints1; // Keypoints calculated for preImage
     cv::Mat descriptors1; // Descriptors calculated for preImage
     void match();
+    void displayMatch();
 
   public:
     FeatureMatcher();

--- a/src/camera_motion_extraction/include/image_subscriber.h
+++ b/src/camera_motion_extraction/include/image_subscriber.h
@@ -5,6 +5,9 @@
 /// header
 #include <opencv2/core/core.hpp>
 #include <image_transport/image_transport.h>
+#include <thread>
+#include <future>
+#include <mutex>
 /// header
 
 
@@ -12,12 +15,14 @@ class RosToCvmat
 {
 private:
     void imageCallback(const sensor_msgs::ImageConstPtr&);
+    std::mutex mtx;
 
 protected:
     cv::Mat image;
     
 public:
     void imageSubscriber(int &argc, char** &argv);
+    void displayRecievedImage();
     virtual void imageCompute();
 };
 

--- a/src/camera_motion_extraction/include/image_subscriber.h
+++ b/src/camera_motion_extraction/include/image_subscriber.h
@@ -15,7 +15,9 @@ class RosToCvmat
 {
 private:
     void imageCallback(const sensor_msgs::ImageConstPtr&);
-    std::mutex mtx;
+    #ifdef DEBUG_MODE
+      std::mutex mtx;
+    #endif
 
 protected:
     cv::Mat image;


### PR DESCRIPTION
Solves the issue where synchronous code of image display with image computation caused slow down in image computation due to wait times for in=mage display. This PR solves this issue by adding a separate threads to display image. It also uses mutexes locks to avoid race conditions between image update (write), and display (read).